### PR TITLE
Removed a stray 'the' from the readme.

### DIFF
--- a/README.adoc.liquid
+++ b/README.adoc.liquid
@@ -45,7 +45,7 @@ The Distributed OSHW Framework (DOF) is built upon {{architecture['1-Stakeholder
 
 == Methodology Documentation
 
-The methodology is being modeled in a series of YAML files under the `architecture` folder.  A script is then used to generate the this readme and the DOF architecture document (located in the `dist` folder).  See the `docs` folder for mataterial on the format of the architecture YAML files.
+The methodology is being modeled in a series of YAML files under the `architecture` folder.  A script is then used to generate this readme and the DOF architecture document (located in the `dist` folder).  See the `docs` folder for mataterial on the format of the architecture YAML files.
 
 Please feel free to join the conversation by posting questions/comments as issues in the http://dof.sliderule.io[DOF repository].
 


### PR DESCRIPTION
Simple fix to the readme's Liquid source file.