### PR TITLE
setup pipeline for deploying to gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Build w/ Hugo & deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - deploy
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build
+        run: bash build.sh
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          # or github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./public

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 node_modules/
+
+# build script generated files
+public/
+
+# github action keys
+gh-pages*

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+# !/usr/bin/env bash
+
+# build script for generating static site with asciidoctor
+
+if [ ! -r ./public ]; then
+    docker run --rm --volume $PWD:/src -w "/src" capsulecorplab/asciidoctor-extended 'asciidoctor README.adoc -o public/index.html'
+fi


### PR DESCRIPTION
## Workflow
Pushing to `deploy` branch will trigger GitHub Actions to run the `build.sh` script and publish output (contents of `public/`) to GitHub Pages.
(See `github/workflows/deploy.yml` for details)

Note: `publish_dir` (in `github/workflows/deploy.yml`) will need to be changed to `master`, if you later decide to migrate the static site to a user/organization page. See https://stackoverflow.com/questions/25559292/github-page-shows-master-branch-not-gh-pages

## Configuration
You will need to generate a public and private ssh key, then add them to `Deploy keys` and `Secrets`, respectively, in the GitHub repo settings.
Follow instructions in https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-create-ssh-deploy-key

## Preview
Site preview available on https://capsulecorplab.github.io/dof/