### PR TITLE
update ci/cd to trigger on main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build w/ Hugo & deploy to GitHub Pages
 on:
   push:
     branches:
-      - deploy
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
updates GitHub Actions for GitHub Pages to deploy on main branch, rather than deploy branch

closes #33 